### PR TITLE
Content-Length on file serve

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,18 +109,6 @@ func main() {
 			w.Header().Add("Server", description)
 		}
 
-		if responseBodyFlag != "" && strings.HasPrefix(responseBodyFlag, "@") {
-			filename := trimFirst(responseBodyFlag)
-			s, err := os.Stat(filename)
-			if err != nil {
-				log.Printf("error: unable to stat file: '%s'", filename)
-				return
-			}
-			if w.Header().Get("Content-Length") == "" {
-				w.Header().Add("Content-Length", strconv.Itoa(int(s.Size())))
-			}
-		}
-
 		if responseBodyFlag != "" {
 			if strings.HasPrefix(responseBodyFlag, "@") {
 				// response is filename
@@ -149,6 +137,8 @@ func main() {
 					log.Printf("error: unable to write response body: %s", err)
 				}
 			}
+		} else {
+			w.WriteHeader(int(statusCodeFlag))
 		}
 
 		if exitAfterFlag != 0 && exitAfterFlag == responseCount {

--- a/main.go
+++ b/main.go
@@ -109,22 +109,42 @@ func main() {
 			w.Header().Add("Server", description)
 		}
 
-		w.WriteHeader(int(statusCodeFlag))
+		if responseBodyFlag != "" && strings.HasPrefix(responseBodyFlag, "@") {
+			filename := trimFirst(responseBodyFlag)
+			s, err := os.Stat(filename)
+			if err != nil {
+				log.Printf("error: unable to stat file: '%s'", filename)
+				return
+			}
+			if w.Header().Get("Content-Length") == "" {
+				w.Header().Add("Content-Length", strconv.Itoa(int(s.Size())))
+			}
+		}
 
 		if responseBodyFlag != "" {
 			if strings.HasPrefix(responseBodyFlag, "@") {
 				// response is filename
 				filename := trimFirst(responseBodyFlag)
+				s, err := os.Stat(filename)
+				if err != nil {
+					log.Printf("error: unable to stat file: '%s'", filename)
+					return
+				}
 				file, err := os.Open(filename)
 				if err != nil {
 					log.Printf("error: unable to open file: '%s'", filename)
 					return
 				}
 				defer quietClose(file)
+				if w.Header().Get("Content-Length") == "" {
+					w.Header().Add("Content-Length", strconv.Itoa(int(s.Size())))
+				}
+				w.WriteHeader(int(statusCodeFlag)) // start sending body
 				if _, err = io.Copy(w, file); err != nil {
 					log.Printf("error: unable to write response body: %s", err)
 				}
 			} else {
+				w.WriteHeader(int(statusCodeFlag)) // start sending body
 				if _, err := w.Write([]byte(responseBodyFlag)); err != nil {
 					log.Printf("error: unable to write response body: %s", err)
 				}


### PR DESCRIPTION
When serving a file, the `Content-Length` header will now be set to the size of the file, if not explicitly set by using a `-H` argument.