### PR TITLE
Bump golang

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: ">=1.19.0"
+        go-version: ">=1.22.0"
 
     - name: Build
       run: make build

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -13,17 +13,17 @@ jobs:
       IMAGE_NAME: ghcr.io/thorsager/surl
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Prepare
         id: prep
         run: |
-          echo ::set-output name=tags::${IMAGE_NAME}:latest
+          echo "tags=${IMAGE_NAME}:latest" >> $GITHUB_OUTPUT
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/publish-on-branch.yml
+++ b/.github/workflows/publish-on-branch.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          echo ::set-output name=tags::${IMAGE_NAME}:${GITHUB_REF##*/}
+          echo "tags=${IMAGE_NAME}:${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          echo ::set-output name=tags::${IMAGE_NAME}:${GITHUB_REF/refs\/tags\//}
+          echo "tags=${IMAGE_NAME}:${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/thorsager/surl
 
-go 1.20
+go 1.22
 
 require github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
This PR bumps the min required golang version to 1.22 fixing #6 , it also updates the workflows to reflect this as well as bumping various action versions, fixing #5 