### PR TITLE
feat: add request logging and directory file serving

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/thorsager/surl
 
-go 1.24
-
-toolchain go1.24.3
+go 1.24.6
 
 require github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/thorsager/surl
 
-go 1.22
+go 1.24
+
+toolchain go1.24.3
 
 require github.com/spf13/pflag v1.0.5

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -35,6 +35,7 @@ var (
 	userFlag            string
 
 	responseCount uint = 0
+	absBaseDir    string
 )
 
 func main() {
@@ -69,24 +70,150 @@ func main() {
 		os.Exit(1)
 	}
 
+	if responseBodyFlag != "" && strings.HasPrefix(responseBodyFlag, "@") {
+		fn := trimFirst(responseBodyFlag)
+		s, err := os.Stat(fn)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
+			pflag.Usage()
+			os.Exit(1)
+		}
+		if s.IsDir() {
+			absBaseDir, err = filepath.Abs(fn)
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
+				pflag.Usage()
+				os.Exit(1)
+			}
+		}
+	}
+
 	srv := http.Server{Addr: addr}
 	description := fmt.Sprintf("surl/%s", version)
 
 	sigChan := make(chan os.Signal, 1)
+	http.Handle("/", requestLogger(globalHandler(description, sigChan)))
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	go func() {
+		log.Printf("starting %s on %s %s", description, addr, desc(exitAfterFlag))
+		if absBaseDir != "" {
+			log.Printf("serving files from: %s", absBaseDir)
+		}
+		if certFileFlag != "" && keyFileFlag != "" {
+			if err := srv.ListenAndServeTLS(certFileFlag, keyFileFlag); !errors.Is(err, http.ErrServerClosed) {
+				log.Fatalf("startup error: %v", err)
+			}
+			return
+		}
+		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("startup error: %v", err)
+		}
+	}()
+
+	// wait for request count
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	shutdownCtx, shutdownRelease := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownRelease()
+
+	if exitAfterFlag != responseCount {
+		log.Printf("shutting down after %d responses", responseCount)
+	}
+	err = srv.Shutdown(shutdownCtx)
+	if err != nil {
+		log.Fatalf("shutdown error: %v", err)
+	}
+}
+
+type ctxLogDataKey struct{}
+type collectingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	size       int
+}
+
+func (crw *collectingResponseWriter) WriteHeader(code int) {
+	crw.statusCode = code
+	crw.ResponseWriter.WriteHeader(code)
+}
+func (crw *collectingResponseWriter) Write(b []byte) (int, error) {
+	n, err := crw.ResponseWriter.Write(b)
+	crw.size += n
+	return n, err
+}
+
+func requestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started := time.Now()
+
+		logData := make(map[string]any)
+		ctx := context.WithValue(r.Context(), ctxLogDataKey{}, logData)
+		r = r.WithContext(ctx)
+		cw := &collectingResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(cw, r)
+
+		log.Printf("%s - %s \"%s %s %s\" %d %d %s %s [%s]%s",
+			logUser(r),
+			r.RemoteAddr,
+			r.Method,
+			logPath(r, logData),
+			r.Proto,
+			cw.statusCode,
+			cw.size,
+			r.Referer(),
+			r.UserAgent(),
+			time.Since(started),
+			logDump(logData),
+		)
+	})
+}
+func logDump(logData map[string]any) string {
+	if d, ok := logData["dump"].([]byte); ok {
+		return fmt.Sprintf("\n%s", indent(hex.Dump(d), 20))
+	}
+	return ""
+}
+
+func indent(s string, spaces int) string {
+	indent := strings.Repeat(" ", spaces)
+	return fmt.Sprintln(indent + strings.ReplaceAll(s, "\n", "\n"+indent))
+}
+
+func logUser(r *http.Request) string {
+	if user, _, ok := r.BasicAuth(); ok {
+		return user
+	}
+	return "???"
+}
+
+func logPath(r *http.Request, logdata map[string]any) string {
+	p := r.URL.Path
+	if logdata != nil {
+		if s, ok := logdata["served-file"]; ok && s != "" {
+			p += fmt.Sprintf(" (%s)", s)
+		}
+	}
+	return p
+}
+
+func addLogData(r *http.Request, key string, value any) {
+	if logData, ok := r.Context().Value(ctxLogDataKey{}).(map[string]any); ok {
+		logData[key] = value
+	}
+}
+
+func globalHandler(description string, sigChan chan os.Signal) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if userFlag != "" {
 			if !validateBasicAuth(r, userFlag) {
 				w.Header().Add("WWW-Authenticate", "Basic realm=\"Auth Required\"")
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
-
 		}
 
 		responseCount += 1
-
-		log.Printf("request: %s %s %s", r.RemoteAddr, r.Method, r.URL)
 
 		if dumpRequestFlag || dumpBodyFlag {
 			dump, err := httputil.DumpRequest(r, dumpBodyFlag)
@@ -94,7 +221,8 @@ func main() {
 				log.Printf("error: unable to dump client request: %s", err)
 				return
 			}
-			log.Printf("\n--\n%q\n--\n", dump)
+			addLogData(r, "dump", dump)
+			// log.Printf("\n--\n%q\n--\n", dump)
 		}
 
 		if len(responseHeadersFlag) != 0 {
@@ -118,6 +246,27 @@ func main() {
 					log.Printf("error: unable to stat file: '%s'", filename)
 					return
 				}
+				if s.IsDir() {
+					requestPath := filepath.Join(filename, filepath.Clean("/"+r.URL.Path))
+					absRequestPath, err := filepath.Abs(requestPath)
+					if err != nil {
+						log.Printf("error: unable to establish absolute path from '%s': %s", requestPath, err)
+						return
+					}
+
+					if !strings.HasPrefix(absRequestPath, absBaseDir) {
+						log.Printf("error: path '%s' outside of base '%s'", requestPath, filename)
+						return
+					}
+					filename = absRequestPath
+
+					s, err = os.Stat(filename)
+					if err != nil {
+						log.Printf("error: unable to stat file: '%s'", filename)
+						return
+					}
+				}
+				addLogData(r, "served-file", filename)
 				file, err := os.Open(filename)
 				if err != nil {
 					log.Printf("error: unable to open file: '%s'", filename)
@@ -145,37 +294,7 @@ func main() {
 			log.Printf("response count of %d reached, shutting down", responseCount)
 			sigChan <- os.Interrupt
 		}
-
 	})
-
-	go func() {
-		if certFileFlag != "" && keyFileFlag != "" {
-			log.Printf("starting %s on %s %s", description, addr, desc(exitAfterFlag))
-			if err := srv.ListenAndServeTLS(certFileFlag, keyFileFlag); !errors.Is(err, http.ErrServerClosed) {
-				log.Fatalf("startup error: %v", err)
-			}
-			return
-		}
-		log.Printf("starting %s on %s %s", description, addr, desc(exitAfterFlag))
-		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("startup error: %v", err)
-		}
-	}()
-
-	// wait for request count
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	<-sigChan
-
-	shutdownCtx, shutdownRelease := context.WithTimeout(context.Background(), 10*time.Second)
-	defer shutdownRelease()
-
-	if exitAfterFlag != responseCount {
-		log.Printf("shutting down after %d responses", responseCount)
-	}
-	err = srv.Shutdown(shutdownCtx)
-	if err != nil {
-		log.Fatalf("shutdown error: %v", err)
-	}
 }
 
 func validAddr(s string) error {
@@ -190,15 +309,19 @@ func validAddr(s string) error {
 }
 
 func validateBasicAuth(r *http.Request, up string) bool {
-	ah := r.Header.Get("Authorization")
-	if ah == "" || !strings.HasPrefix(ah, "Basic ") {
-		return false
+	if user, pass, ok := r.BasicAuth(); ok {
+		return up == user+":"+pass
 	}
-	ah = strings.TrimPrefix(ah, "Basic ")
-	if clear, err := base64.StdEncoding.DecodeString(ah); err != nil || string(clear) != up {
-		return false
-	}
-	return true
+	return false
+	// ah := r.Header.Get("Authorization")
+	// if ah == "" || !strings.HasPrefix(ah, "Basic ") {
+	// 	return false
+	// }
+	// ah = strings.TrimPrefix(ah, "Basic ")
+	// if clear, err := base64.StdEncoding.DecodeString(ah); err != nil || string(clear) != up {
+	// 	return false
+	// }
+	// return true
 }
 
 func parseAddr() (string, error) {


### PR DESCRIPTION
- Add requestLogger middleware to log HTTP requests with user, path, status, size, referer, user agent, duration, and request dump (hex-encoded).
- Support serving files from a directory when responseBodyFlag points to a directory, ensuring requests stay within the base directory.
- Refactor basic auth validation to use r.BasicAuth().
- Refactor server startup and shutdown logic for clarity.
- bumping to go 1.24 fixing #10 