### PR TITLE
fix(ci): ignore tags in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security tab
         if: ${{ github.event_name == 'pull_request' }}
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,11 +64,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action
@@ -78,10 +76,11 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -91,7 +90,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
+          image-ref: ${{ steps.build-and-push.outputs.imageid }}
           format: 'json'
           output: 'trivy-results.json'
           exit-code: '0'
@@ -127,7 +126,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && steps.trivy-check.outputs.has_vulnerabilities == 'true' }}
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
+          image-ref: ${{ steps.build-and-push.outputs.imageid }}
           format: 'table'
           output: 'trivy-table.txt'
           exit-code: '0'
@@ -140,7 +139,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
+          image-ref: ${{ steps.build-and-push.outputs.imageid }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
@@ -168,7 +167,7 @@ jobs:
               comment = '✅ Trivy scan passed - No CRITICAL or HIGH vulnerabilities found';
             } else {
               // Detailed message with full table
-              const image = '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}';
+              const image = '${{ steps.build-and-push.outputs.imageid }}';
               comment = `## ⚠️ Trivy Security Scan - Vulnerabilities Detected\n\n`;
               comment += `**Image:** \`${image}\`\n\n`;
               comment += `**Found ${vulnCount} vulnerabilities (CRITICAL/HIGH severity)**\n\n`;

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches: 
       - '**'
+    tags-ignore:
+      - '**'
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ on:
   push:
     branches: 
       - '**'
-    tags-ignore:
-      - '**'
   pull_request:
     branches: [ "main" ]
+  tags-ignore:
+    - '**'
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
 FROM golang:1-alpine AS build
 RUN apk add --update --no-cache make git
-RUN mkdir /build
 WORKDIR /build
-COPY go.mod go.sum /build/
-RUN go list -m all
-RUN go mod download
 
-ADD . /build
-RUN CGO_ENABLED=0 GOOS=linux make
+# Copy go.mod and go.sum first for better layer caching
+COPY go.mod go.sum ./
+
+# Download dependencies with cache mount for go modules
+# This layer only rebuilds when go.mod or go.sum changes
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy source code (this invalidates cache only when code changes)
+COPY . .
+
+# Build with cache mount for go build cache
+# This dramatically speeds up rebuilds by caching compiled packages
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux make
 
 FROM alpine:3
 LABEL org.opencontainers.image.source=https://github.com/thorsager/surl

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ image_tag=$(version)
 .PHONY: all
 all: test build
 
-build: get
+build:
 	go build -v -a -tags netgo --ldflags='-X main.version=$(version)' -o $(binary) ./...
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ surl -d '{"error_code":"-1","message":"dunno"}' \
     -H 'Content-Type: application/json' -s 500 \
     :8080
 ```
+
+```bash
+docker run -p 8080:8080 ghcr.io/thorsager/surl \
+    -H "Location: https://www.google.com" \
+    -s 307 \
+    -d '<html><body><a href="https://www.google.com">google</a></body></html>' \
+    :8080
+```


### PR DESCRIPTION
Update the Go workflow to ignore tag pushes, preventing unnecessary CI runs on tag events. Also, add a Docker usage example to the README for clarity on running the service with Docker, including custom headers, status, and body.