### PR TITLE
fix(ci): ignore tags only for push, not pull_request

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ on:
   push:
     branches: 
       - '**'
+    tags-ignore:
+      - '**'
   pull_request:
     branches: [ "main" ]
-  tags-ignore:
-    - '**'
 
 jobs:
   build:


### PR DESCRIPTION
Move the tags-ignore rule to apply only to push events, ensuring that pull_request events are not affected. This prevents unintended exclusion of pull request workflows triggered by tags.